### PR TITLE
Introduce request_tags to capture tags from the current request

### DIFF
--- a/lib/rackstash/framework/base.rb
+++ b/lib/rackstash/framework/base.rb
@@ -4,9 +4,12 @@ module Rackstash
       def setup(config={})
         Rackstash.request_fields = config.rackstash[:request_fields]
         Rackstash.fields = config.rackstash[:fields] || HashWithIndifferentAccess.new
+
         Rackstash.source = config.rackstash[:source]
         Rackstash.log_level = config.rackstash[:log_level] || :info
+
         Rackstash.tags = config.rackstash[:tags] || []
+        Rackstash.request_tags = config.rackstash[:request_tags] || []
       end
     end
   end

--- a/lib/rackstash/log_subscriber.rb
+++ b/lib/rackstash/log_subscriber.rb
@@ -14,6 +14,8 @@ module Rackstash
 
       Rails.logger.fields.reverse_merge!(data)
       Rails.logger.fields.merge! request_fields(payload)
+
+      Rails.logger.tags.push *request_tags(payload)
     end
 
     def redirect_to(event)
@@ -98,6 +100,10 @@ module Rackstash
       end
     end
 
+    def request_tags(payload)
+      payload[:rackstash_request_tags] || []
+    end
+
     def request_fields(payload)
       payload[:rackstash_request_fields] || {}
     end
@@ -108,6 +114,7 @@ module Rackstash
 
     def append_info_to_payload(payload)
       super
+      payload[:rackstash_request_tags] = Rackstash.request_tags(self)
       payload[:rackstash_request_fields] = Rackstash.request_fields(self)
     end
   end

--- a/lib/rackstash/rails_ext/action_controller.rb
+++ b/lib/rackstash/rails_ext/action_controller.rb
@@ -84,6 +84,9 @@ module Rackstash
 
           request_fields = Rackstash.request_fields(self)
           logger.fields.merge!(request_fields) if request_fields
+
+          request_tags = Rackstash.request_tags(self)
+          logger.tags.push *request_tags
         end
       end
 

--- a/lib/rackstash/version.rb
+++ b/lib/rackstash/version.rb
@@ -1,3 +1,3 @@
 module Rackstash
-  VERSION = "0.2.0"
+  VERSION = "0.2.1"
 end


### PR DESCRIPTION
`Rackstash.request_tags=` accepts an Array of callable objects or strings. Callable objects will be called with the current request.

Usage:

```ruby
  config.rackstash.request_tags = [
    lambda { |request| request.subdomains.first || "no-account" },
    lambda { |request|
      case
      when request.subdomains.first == "37smonitoring"
        "monitoring"
      when request.path.starts_with?("/queenbee")
        "queenbee"
      else
        "web"
      end
    }
  ]
```