### PR TITLE
Call request_fields with the current request

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,23 +102,22 @@ config.rackstash.tags = ['ruby', 'rails2']
 
 # Additional fields which are included into each log event that
 # originates from a captured request.
-# Can either be a Hash or an object which responds to to_proc which
-# subsequently returns a Hash. If it is the latter, the proc will be exceuted
-# similar to an after filter in every request of the controller and thus has
-# access to the controller state after the request was handled.
-config.rackstash.request_fields = lambda do |controller|
+# Can either be a Hash or a callable object which responds to #call and which
+# subsequently returns a Hash. If it is the latter, the object will called
+# with the `request` object after the request is handled.
+config.rackstash.request_fields = lambda { |request|
   {
     :host => request.host,
     :source_ip => request.remote_ip,
     :user_agent => request.user_agent
   }
-end
+}
 
 # Additional fields that are to be included into every emitted log, both
 # buffered and not. You can use this to add global state information to the
 # log, e.g. from the current thread or from the current environment.
-# Similar to the request_fields, this can be either a static Hash or an
-# object which responds to to_proc and returns a Hash there.
+# Similar to the request_fields, this can be either a static Hash or a
+# callable object which responds to #call and returns a Hash.
 #
 # Note that the proc is not executed in a controller instance and thus doesn't
 # directly have access to the controller state.

--- a/lib/rackstash.rb
+++ b/lib/rackstash.rb
@@ -24,12 +24,9 @@ module Rackstash
   mattr_writer :request_fields
   self.request_fields = HashWithIndifferentAccess.new
   def self.request_fields(controller)
-    if @@request_fields.respond_to?(:call)
-      ret = controller.instance_eval(&@@request_fields)
-    else
-      ret = @@request_fields
-    end
-    HashWithIndifferentAccess.new(ret)
+    fields = @@request_fields
+    fields = fields.call(controller.request) if fields.respond_to?(:call)
+    HashWithIndifferentAccess.new(fields)
   end
 
   # Custom fields that will be merged with every log object, be it a captured
@@ -42,12 +39,9 @@ module Rackstash
   mattr_writer :fields
   self.fields = HashWithIndifferentAccess.new
   def self.fields
-    if @@fields.respond_to?(:call)
-      ret = @@fields.call
-    else
-      ret = @@fields
-    end
-    HashWithIndifferentAccess.new(ret)
+    fields = @@fields
+    fields = fields.call if fields.respond_to?(:call)
+    HashWithIndifferentAccess.new(fields)
   end
 
   # The source attribute in the generated Logstash output

--- a/lib/rackstash/version.rb
+++ b/lib/rackstash/version.rb
@@ -1,3 +1,3 @@
 module Rackstash
-  VERSION = "0.2.1"
+  VERSION = "0.3.0"
 end

--- a/test/rackstash_test.rb
+++ b/test/rackstash_test.rb
@@ -50,9 +50,7 @@ describe Rackstash do
     end
 
     let(:controller) do
-      controller = Class.new(Object){attr_accessor :status}.new
-      controller.status = "running"
-      controller
+      Struct.new(:request).new(Struct.new(:status).new(200))
     end
 
     it "won't be included in unbuffered mode" do
@@ -72,31 +70,29 @@ describe Rackstash do
     end
 
     it "can be defined as a proc" do
-      Rackstash.request_fields = proc do |controller|
+      Rackstash.request_fields = proc do |request|
         {
           :foo => :bar,
-          :status => @status,
-          :instance_status => controller.status
+          :status => request.status
         }
       end
 
       Rackstash.request_fields(controller).must_be_instance_of HashWithIndifferentAccess
-      Rackstash.request_fields(controller).must_equal({"foo" => :bar, "status" => "running", "instance_status" => "running"})
+      Rackstash.request_fields(controller).must_equal({"foo" => :bar, "status" => 200})
 
       # TODO: fake a real request and ensure that the field gets set in the log output
     end
 
     it "can be defined as a lambda" do
-      Rackstash.request_fields = lambda do |controller|
+      Rackstash.request_fields = lambda do |request|
         {
           :foo => :bar,
-          :status => @status,
-          :instance_status => controller.status
+          :status => request.status
         }
       end
 
       Rackstash.request_fields(controller).must_be_instance_of HashWithIndifferentAccess
-      Rackstash.request_fields(controller).must_equal({"foo" => :bar, "status" => "running", "instance_status" => "running"})
+      Rackstash.request_fields(controller).must_equal({"foo" => :bar, "status" => 200})
 
       # TODO: fake a real request and ensure that the field gets set in the log output
     end


### PR DESCRIPTION
Prefer yielding the controller's `request` object over evaluating the Proc in the controller context, which seems broad and unnecessary.