### PR TITLE
Expose the #tagged method on BufferedLogger so it can be used through the logger instance

### DIFF
--- a/lib/rackstash/buffered_logger.rb
+++ b/lib/rackstash/buffered_logger.rb
@@ -113,6 +113,10 @@ module Rackstash
       buffer && buffer[:tags]
     end
 
+    def tagged(*tags)
+      Rackstash.tagged(*tags) { yield }
+    end
+
     def source=(value)
       @source = value
       @source_is_customized = true

--- a/test/buffered_logger_test.rb
+++ b/test/buffered_logger_test.rb
@@ -139,6 +139,14 @@ describe Rackstash::BufferedLogger do
       json["@message"].must_equal "   [INFO] Hello"
     end
 
+    it "can set additional tags for the duration of a block" do
+      subject.tagged("foo", "bar") { subject.info "Testing" }
+      json["@tags"].must_equal ["foo", "bar"]
+
+      subject.info "Testing"
+      json["@tags"].must_equal []
+    end
+
     it "can set additional fields" do
       subject.with_buffer do
         subject.fields[:foo] = :bar


### PR DESCRIPTION
Allows us to quack like Active Support's TaggedLogger so that instead of:

```ruby
Rackstash.tagged("console") { # Things that log }
```

we can do this:

```ruby
Rails.logger.tagged("console") { # Things that log }
```

/cc @anoldguy 